### PR TITLE
Take bracket length into account when extracting value

### DIFF
--- a/src/placeholderediting.js
+++ b/src/placeholderediting.js
@@ -70,7 +70,10 @@ export default class PlaceholderEditing extends Plugin {
       },
       model: (viewElement, writer) => {
         // Extract the "name" from "{name}".
-        const name = viewElement.getChild(0).data.slice(1, -1);
+        const name = viewElement.getChild(0).data.slice(
+            config.get("placeholderBrackets.open").length,
+            0 - config.get("placeholderBrackets.close").length
+        );
 
         const modelWriter = writer.writer || writer;
 


### PR DESCRIPTION
The custom brackets option I introduced the other day resulted in adding 1 character on save every time.

This happens because the editing command was not adapted to the length of the custom brackets and always assumes a length of 1.

This change fixes that.